### PR TITLE
Disable App Transport Security to for OS X 10.11 SDK

### DIFF
--- a/WKWebViewTest/Info.plist
+++ b/WKWebViewTest/Info.plist
@@ -30,5 +30,10 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
The example does not load any of the pages when building using the OS X 10.11 SDK due to new enforcements of App Transport Security. For the purposes of making this useful example work I simply disabled it.
